### PR TITLE
Fix puppeteer cannot navigate to "Notes" tab

### DIFF
--- a/src/is-academia.ts
+++ b/src/is-academia.ts
@@ -117,15 +117,12 @@ const getIsAcademiaNotes = async (
   await page.waitForFunction(() => document.readyState === "complete");
   await humanDelay();
 
-  const selectorNavNotes = "//li[@id='410']";
-  await page.waitForXPath(selectorNavNotes);
-  const button0 = (
-    await page.$x(selectorNavNotes)
-  )[0] as unknown as ElementHandle;
-
-  if (button0) {
-    await button0.click();
-  }
+  await page.evaluate(() => {
+    const element = document.getElementById("410");
+    if (element) {
+      element.click();
+    }
+  });
 
   await humanDelay();
 


### PR DESCRIPTION
## Improve the interaction with the "Notes des contrôles continus" tab button

Previously, clicking on the tab could fail in headless mode or on smaller screens, because the tab got hidden by other elements.

Instead of relying on Puppeteer's page.waitForXPath(), we now directly evaluate JavaScript code using page.evaluate()