### PR TITLE
Fix incorrect old/new note in findDifferences()

### DIFF
--- a/src/modules.ts
+++ b/src/modules.ts
@@ -107,7 +107,7 @@ export const findDifferences = (
                 module: oldModule,
                 course: oldCourse,
                 oldNote: oldNote,
-                newNote: oldNote,
+                newNote: newNote,
               });
             }
           });


### PR DESCRIPTION
In some case, the method `findDifferences()` incorrectly assign the value of `oldNote` in `newNote`

Example : when the old value was `4.5` and the new value was `5.5`, the difference created by the method incorrectly contained `4.5` for both the `oldNote` and `newNote`.

Probably a copy-paste error.