### PR TITLE
Fix simpleGit use parent repo instead dedicated one

### DIFF
--- a/src/git-history.ts
+++ b/src/git-history.ts
@@ -1,6 +1,6 @@
 import * as fs from "fs";
 import path from "node:path";
-import { simpleGit, SimpleGit } from "simple-git";
+import {CheckRepoActions, simpleGit, SimpleGit} from "simple-git";
 import { format } from "date-fns";
 import { env } from "./env";
 import { logger } from "./logger";
@@ -24,10 +24,10 @@ export const gitHistory = async (
   tmpFile: string,
 ): Promise<boolean> => {
   /*
-   * Create Git Folder
+   * Ensure Git folder exists
    */
   if (!fs.existsSync(gitFolder)) {
-    logger.info("Git folder must exist.");
+    logger.info(`Git folder (${gitFolder}) must exist on your local machine.`);
     return false;
   }
 
@@ -38,7 +38,7 @@ export const gitHistory = async (
   /*
    * Init Git Repo if not exist
    */
-  const isRepo = await git.checkIsRepo();
+  const isRepo = await git.checkIsRepo(CheckRepoActions.IS_REPO_ROOT);
   if (!isRepo) {
     await git.init();
     logger.info("Initialized a new git repository.");


### PR DESCRIPTION

This problem only occurs when the project's git repository (`.git`) exists at runtime. If you've removed it, the app works as expected.

## Context :
When utilizing Simple Git to track note changes within a git repo, the app will first initialize the git repo in the dedicated directory.
To make sure that the repo isn't initialized more than once, we check if the directory is already a repo with `checkIsRepo()`.

## Problem :
By default, the `checkIsRepo()` method only check if the directory is a descendant (subdirectory) of a git repository. 
The app will therefore not initialize the repo dedicated to track grades change, and will start to interact with the parent repository of this project instead.

## Solution
To avoid this behavior, I've added the `IS_REPO_ROOT` option. 
This way, we are sure that the app will create the `.git` folder inside the grade directory. 
See the [Simple Git documentation](https://github.com/steveukx/git-js?tab=readme-ov-file#git-rev-parse--repo-properties).